### PR TITLE
Bump Version 1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,117 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.4.1] - 2026-01-17
+
+### Fixed
+- **Critical Fix**: Previous week sensor now shows correct values
+  - Fixed data fetching to include complete previous week (Monday-Sunday)
+  - Previously only fetched last 7 days, missing start of previous week when viewed mid-week
+  - Now fetches from previous Monday onwards to ensure all weekly data is available
+  - Resolves issue where previous week showed ~30% of actual usage
+- **Critical Fix**: Estimated meter reading calculation now includes correct months
+  - Fixed monthly period inclusion logic to compare against actual official reading date
+  - When official reading is on 1st of month: compares monthly start dates against the official reading date (not month boundary)
+  - When official reading is mid-month: excludes that month (partial month covered by daily data)
+  - Prevents including historical months before the official reading
+  - Resolves issue where estimated reading was too high (was including 8 months instead of 4)
+  - For Oct 1st, 2025 official reading: now correctly includes only Oct, Nov, Dec 2025, Jan 2026 (4 periods)
+- **Fix**: Removed invalid state class from Daily Average sensor
+  - Removed `MEASUREMENT` state class which is incompatible with `WATER` device class
+  - Sensor now correctly represents an average rate without statistics tracking
+  - Resolves Home Assistant warning about impossible state class configuration
+- **Critical Fix**: Changed from hourly to daily data fetching to match website behavior
+  - Now uses `DAY_INTERVAL` instead of `HOUR_INTERVAL` for daily readings
+  - Eliminates potential data discrepancies from hourly aggregation
+  - Matches exact API behavior used by Severn Trent website
+  - Should resolve remaining value mismatches between integration and website
+- **Critical Fix**: Yesterday's usage now shows correct date
+  - Changed from using most recent date in response to calculating yesterday as (today - 1 day)
+  - Matches website behavior which explicitly fetches data for yesterday's date
+  - Resolves issue where today's partial data was shown instead of yesterday's complete day
+
+## [1.4.0] - 2026-01-17
+
+### Breaking Changes
+- **Removed** `sensor.severn_trent_weekly_total` (replaced with week-to-date sensor)
+  - Users will need to update any automations, dashboards, or scripts that reference this sensor
+  - Replace with `sensor.severn_trent_week_to_date` or `sensor.severn_trent_previous_week`
+
+### Added
+- **New Sensor**: `sensor.severn_trent_week_to_date` - Shows water consumption from Monday to present in the current week
+  - Attributes include: `week_start`, `days_in_week`
+  - Updates daily as new data becomes available
+  - Uses Monday as the start of the week
+- **New Sensor**: `sensor.severn_trent_previous_week` - Shows total water consumption for the previous complete week (Monday-Sunday)
+  - Attributes include: `week_start`, `week_end`, `days_in_week`
+  - Perfect for weekly comparisons and tracking
+- Added `device_class` to all water consumption sensors for proper Home Assistant integration
+- Enhanced logging with warnings for invalid measurement values
+
+### Fixed
+- **Critical Fix**: Corrected state classes for proper Home Assistant long-term statistics
+  - `sensor.severn_trent_yesterday_usage` now uses `TOTAL_INCREASING` instead of `TOTAL`
+  - `sensor.severn_trent_daily_average` now uses correct unit of measurement
+  - All sensors now properly integrate with Home Assistant's Energy Dashboard
+- **Critical Fix**: Improved estimated meter reading calculation to prevent double-counting
+  - If official reading is mid-month (e.g., Oct 15th), now fetches daily data from that date to end of month
+  - Uses monthly data only for complete months after the official reading month
+  - Previously could double-count water usage from partial months
+- **Critical Fix**: Replaced string-based date comparisons with proper datetime comparisons
+  - More robust and prevents edge cases with different date formats
+  - Added proper error handling for invalid date formats
+- Removed hardcoded unit string formatting (no more `"m³/d"` strings)
+- Improved error handling throughout with specific warning messages instead of silent failures
+
+### Changed
+- Updated API to accept official reading date parameter for smarter data fetching
+- Data coordinator now fetches manual readings first, then uses official date for smart meter queries
+- Enhanced estimated meter reading attributes to show both daily and monthly periods included
+- Updated estimation note to reflect new calculation method
+
+### Technical Improvements
+- Better separation of concerns between daily and monthly data handling
+- Reduced API calls while maintaining accuracy
+- More detailed debug logging for troubleshooting
+- Improved data validation with proper exception handling
+
+## [1.3.0] - 2024-XX-XX
+
+### Changed
+- Switched authentication to a browser token → API key flow
+- Added reauthentication support for refreshing the API key
+
+## [1.2.0] - 2024-XX-XX
+
+### Added
+- Added estimated current meter reading sensor
+- Fetches monthly usage data (past 12 months) for accurate estimation
+- Improved calculation: official reading + monthly totals (including partial current month)
+
+## [1.1.0] - 2024-XX-XX
+
+### Added
+- Added automatic discovery of account numbers
+- Added automatic discovery of meter identifiers
+- Simplified setup to just email and password
+- Added support for multiple accounts
+- Added manual meter reading sensor with historical data
+
+## [1.0.0] - 2024-XX-XX
+
+### Added
+- Initial release
+- Smart meter daily usage tracking
+- 7-day average and weekly total sensors
+- Integration with Severn Trent Kraken API
+- Home Assistant config flow setup
+
+[1.4.0]: https://github.com/xpenno255/ha_severn_trent/compare/v1.3.0...v1.4.0
+[1.3.0]: https://github.com/xpenno255/ha_severn_trent/compare/v1.2.0...v1.3.0
+[1.2.0]: https://github.com/xpenno255/ha_severn_trent/compare/v1.1.0...v1.2.0
+[1.1.0]: https://github.com/xpenno255/ha_severn_trent/compare/v1.0.0...v1.1.0
+[1.0.0]: https://github.com/xpenno255/ha_severn_trent/releases/tag/v1.0.0

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -1,0 +1,163 @@
+# Troubleshooting Data Discrepancies
+
+This guide helps diagnose discrepancies between the integration values and the Severn Trent website.
+
+## Common Causes of Discrepancies
+
+### 1. **Time Zone Differences**
+- The integration uses local time for "yesterday" and week calculations
+- Severn Trent API may use UTC or a different time zone
+- This can cause off-by-one-day errors
+
+### 2. **Data Aggregation Methods**
+- **Hourly to Daily**: We aggregate hourly readings into daily totals
+- **Daily to Weekly**: We sum daily readings for week calculations
+- **Monthly Data**: May include partial periods differently
+- The website might use different aggregation logic
+
+### 3. **Data Availability Timing**
+- Smart meter data has processing delays
+- "Yesterday" might not include the most recent hours
+- Different systems may have different data freshness
+
+### 4. **Reading Types**
+- **HOUR_INTERVAL**: Hourly smart meter readings
+- **DAY_INTERVAL**: Daily aggregated readings
+- **MONTH_INTERVAL**: Monthly aggregated readings
+- The website might prioritize different reading types
+
+### 5. **Week Calculations**
+- Integration uses Monday as week start
+- Website might use Sunday or a different day
+- This can cause weekly totals to differ
+
+### 6. **Meter Reading vs Usage**
+- **Cumulative readings**: Total meter position (like odometer)
+- **Usage readings**: Water consumed in a period
+- Make sure you're comparing like-with-like
+
+## Enable Debug Logging
+
+Add this to your `configuration.yaml`:
+
+```yaml
+logger:
+  default: info
+  logs:
+    custom_components.severn_trent: debug
+```
+
+Then restart Home Assistant.
+
+## What to Check in Logs
+
+Look for these key log messages:
+
+### Daily Data Processing
+```
+Found X hourly measurements
+Daily totals: {'2024-01-15': 1.234, '2024-01-16': 2.345}
+Yesterday (2024-01-16): 2.345 m³
+```
+
+### Week Calculations
+```
+Current week starts: 2024-01-15
+Previous week: 2024-01-08 to 2024-01-14
+Week to date usage: 5.678 m³ (3 days)
+Previous week usage: 12.345 m³
+```
+
+### Monthly Data
+```
+Found X monthly readings
+Monthly reading: 2024-01-01 = 9.841 m³
+```
+
+### Estimated Meter Reading
+```
+Calculating estimated reading:
+  Official reading: 272.0 on 2024-10-15
+  Monthly readings available: 3
+  Daily readings available: 16
+  Daily reading: 2024-10-16 = 0.123 m³
+  Monthly reading: 2024-11-01 = 9.2 m³ (included)
+  Total usage since official: 11.5 m³
+  Estimated current: 283.5 m³
+```
+
+## Comparison Checklist
+
+When comparing with the Severn Trent website:
+
+- [ ] **Check the dates**: Are you comparing the same time period?
+- [ ] **Check the time zone**: Does the website show times in GMT/BST?
+- [ ] **Check units**: Both should be in m³ (cubic meters)
+- [ ] **Check reading type**: Usage vs cumulative reading
+- [ ] **Check week definition**: Monday-Sunday vs Sunday-Saturday
+- [ ] **Note the timestamp**: When was data last updated on each platform?
+
+## Known Differences
+
+### Yesterday's Usage
+- **Integration**: Sums all hourly readings for the previous calendar day
+- **Website**: May show a different aggregation period
+
+### Week Totals
+- **Integration**: Monday (00:00) to Sunday (23:59)
+- **Website**: May use different week boundaries
+
+### Estimated Meter Reading
+- **Integration**: Official reading + daily (partial month) + monthly (complete months)
+- **Website**: May use different estimation method
+
+## Reporting Issues
+
+If discrepancies persist, please report with:
+
+1. **Screenshots**: Both integration and website values
+2. **Dates**: Clearly show what period you're comparing
+3. **Logs**: Debug logs showing the calculations (remove sensitive info)
+4. **Time**: When you captured both values
+5. **Time Zone**: Your Home Assistant time zone setting
+
+## Manual Verification
+
+You can manually verify calculations:
+
+### For Yesterday's Usage:
+1. Check logs for hourly measurements for that date
+2. Sum all hourly values yourself
+3. Compare with integration value
+
+### For Weekly Usage:
+1. Check logs for daily totals
+2. Sum the days in the week period
+3. Compare with integration value
+
+### For Estimated Reading:
+1. Note your last official reading and date from logs
+2. Add up monthly usage since that date (from logs)
+3. Add any daily usage for partial months
+4. Compare with integration value
+
+## Quick Fixes to Try
+
+1. **Reload the integration**
+   - Settings → Devices & Services → Severn Trent → Reload
+
+2. **Force an update**
+   ```yaml
+   service: homeassistant.update_entity
+   target:
+     entity_id: sensor.severn_trent_yesterday_usage
+   ```
+
+3. **Check data freshness**
+   - Look at the `last_updated` attribute on sensors
+   - Compare with website's last update time
+
+4. **Clear and restart**
+   - Remove the integration
+   - Restart Home Assistant
+   - Re-add the integration with fresh API key

--- a/custom_components/severn_trent/manifest.json
+++ b/custom_components/severn_trent/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "hub",
   "iot_class": "cloud_polling",
   "requirements": [],
-  "version": "1.3.0"
+  "version": "1.4.1"
 }

--- a/custom_components/severn_trent/sensor.py
+++ b/custom_components/severn_trent/sensor.py
@@ -1,7 +1,7 @@
 """Sensor platform for Severn Trent Water integration."""
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timedelta
 import logging
 from typing import Any
 
@@ -35,17 +35,20 @@ async def async_setup_entry(
     sensors = [
         SevernTrentYesterdayUsageSensor(coordinator, account_number),
         SevernTrentAverageDailyUsageSensor(coordinator, account_number),
-        SevernTrentWeeklyTotalSensor(coordinator, account_number),
+        SevernTrentWeekToDateSensor(coordinator, account_number),
+        SevernTrentPreviousWeekSensor(coordinator, account_number),
         SevernTrentMeterReadingSensor(coordinator, account_number),
         SevernTrentEstimatedMeterReadingSensor(coordinator, account_number),
     ]
-    
+
     async_add_entities(sensors)
 
 class SevernTrentYesterdayUsageSensor(CoordinatorEntity, SensorEntity):
     """Sensor for yesterday's water usage."""
 
-    _attr_state_class = SensorStateClass.TOTAL
+    _attr_device_class = SensorDeviceClass.WATER
+    _attr_state_class = SensorStateClass.TOTAL_INCREASING
+    _attr_native_unit_of_measurement = UnitOfVolume.CUBIC_METERS
     _attr_icon = "mdi:water"
 
     def __init__(
@@ -67,18 +70,11 @@ class SevernTrentYesterdayUsageSensor(CoordinatorEntity, SensorEntity):
         return self.coordinator.data["smart_meter"].get("yesterday_usage")
 
     @property
-    def native_unit_of_measurement(self) -> str | None:
-        """Return the unit of measurement."""
-        if not self.coordinator.data or "smart_meter" not in self.coordinator.data:
-            return UnitOfVolume.CUBIC_METERS
-        return self.coordinator.data["smart_meter"].get("unit", UnitOfVolume.CUBIC_METERS)
-
-    @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return additional attributes."""
         if not self.coordinator.data or "smart_meter" not in self.coordinator.data:
             return {}
-        
+
         return {
             "date": self.coordinator.data["smart_meter"].get("yesterday_date"),
             "meter_id": self.coordinator.data["smart_meter"].get("meter_id"),
@@ -87,7 +83,7 @@ class SevernTrentYesterdayUsageSensor(CoordinatorEntity, SensorEntity):
 class SevernTrentAverageDailyUsageSensor(CoordinatorEntity, SensorEntity):
     """Sensor for average daily water usage over the last 7 days."""
 
-    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_device_class = SensorDeviceClass.WATER
     _attr_icon = "mdi:water-pump"
 
     def __init__(
@@ -111,29 +107,28 @@ class SevernTrentAverageDailyUsageSensor(CoordinatorEntity, SensorEntity):
     @property
     def native_unit_of_measurement(self) -> str | None:
         """Return the unit of measurement."""
-        if not self.coordinator.data or "smart_meter" not in self.coordinator.data:
-            return UnitOfVolume.CUBIC_METERS
-        unit = self.coordinator.data["smart_meter"].get("unit", UnitOfVolume.CUBIC_METERS)
-        return f"{unit}/d"
+        return UnitOfVolume.CUBIC_METERS
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return additional attributes."""
         if not self.coordinator.data or "smart_meter" not in self.coordinator.data:
             return {}
-        
+
         # Include recent readings for history
         all_readings = self.coordinator.data["smart_meter"].get("all_readings", [])
-        
+
         return {
             "recent_readings": all_readings[:7] if all_readings else [],
             "period": "7 days",
         }
 
-class SevernTrentWeeklyTotalSensor(CoordinatorEntity, SensorEntity):
-    """Sensor for total water usage over the last 7 days."""
+class SevernTrentWeekToDateSensor(CoordinatorEntity, SensorEntity):
+    """Sensor for water usage from Monday to present in current week."""
 
+    _attr_device_class = SensorDeviceClass.WATER
     _attr_state_class = SensorStateClass.TOTAL
+    _attr_native_unit_of_measurement = UnitOfVolume.CUBIC_METERS
     _attr_icon = "mdi:water-outline"
 
     def __init__(
@@ -144,32 +139,66 @@ class SevernTrentWeeklyTotalSensor(CoordinatorEntity, SensorEntity):
         """Initialize the sensor."""
         super().__init__(coordinator)
         self._account_number = account_number
-        self._attr_name = "Severn Trent Weekly Total"
-        self._attr_unique_id = f"{account_number}_weekly_total"
+        self._attr_name = "Severn Trent Week to Date"
+        self._attr_unique_id = f"{account_number}_week_to_date"
 
     @property
     def native_value(self) -> float | None:
         """Return the state of the sensor."""
         if not self.coordinator.data or "smart_meter" not in self.coordinator.data:
             return None
-        return self.coordinator.data["smart_meter"].get("total_7day_usage")
-
-    @property
-    def native_unit_of_measurement(self) -> str | None:
-        """Return the unit of measurement."""
-        if not self.coordinator.data or "smart_meter" not in self.coordinator.data:
-            return UnitOfVolume.CUBIC_METERS
-        return self.coordinator.data["smart_meter"].get("unit", UnitOfVolume.CUBIC_METERS)
+        return self.coordinator.data["smart_meter"].get("week_to_date_usage")
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return additional attributes."""
         if not self.coordinator.data or "smart_meter" not in self.coordinator.data:
             return {}
-        
+
+        smart_data = self.coordinator.data["smart_meter"]
         return {
-            "period": "7 days",
-            "days_included": len(self.coordinator.data["smart_meter"].get("all_readings", [])),
+            "week_start": smart_data.get("week_start_date"),
+            "days_in_week": smart_data.get("days_in_current_week"),
+        }
+
+
+class SevernTrentPreviousWeekSensor(CoordinatorEntity, SensorEntity):
+    """Sensor for water usage for the previous week (Monday-Sunday)."""
+
+    _attr_device_class = SensorDeviceClass.WATER
+    _attr_state_class = SensorStateClass.TOTAL
+    _attr_native_unit_of_measurement = UnitOfVolume.CUBIC_METERS
+    _attr_icon = "mdi:water-check-outline"
+
+    def __init__(
+        self,
+        coordinator: DataUpdateCoordinator,
+        account_number: str,
+    ) -> None:
+        """Initialize the sensor."""
+        super().__init__(coordinator)
+        self._account_number = account_number
+        self._attr_name = "Severn Trent Previous Week"
+        self._attr_unique_id = f"{account_number}_previous_week"
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the state of the sensor."""
+        if not self.coordinator.data or "smart_meter" not in self.coordinator.data:
+            return None
+        return self.coordinator.data["smart_meter"].get("previous_week_usage")
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return additional attributes."""
+        if not self.coordinator.data or "smart_meter" not in self.coordinator.data:
+            return {}
+
+        smart_data = self.coordinator.data["smart_meter"]
+        return {
+            "week_start": smart_data.get("previous_week_start_date"),
+            "week_end": smart_data.get("previous_week_end_date"),
+            "days_in_week": 7,
         }
 
 class SevernTrentMeterReadingSensor(CoordinatorEntity, SensorEntity):
@@ -247,56 +276,83 @@ class SevernTrentEstimatedMeterReadingSensor(CoordinatorEntity, SensorEntity):
         """Return the state of the sensor."""
         if not self.coordinator.data:
             return None
-        
+
         manual_data = self.coordinator.data.get("manual_meter", {})
         smart_data = self.coordinator.data.get("smart_meter", {})
-        
-        # Need both manual reading and monthly usage data
+
+        # Need both manual reading and usage data
         if not manual_data or not smart_data:
             return None
-        
+
         latest_official = manual_data.get("latest_reading")
         official_date = manual_data.get("reading_date")
         monthly_readings = smart_data.get("monthly_readings", [])
-        
+        daily_readings = smart_data.get("daily_readings_since_official", [])
+
         if not latest_official or not official_date:
             return None
-        
-        # Log for debugging
-        import logging
-        _LOGGER = logging.getLogger(__name__)
+
         _LOGGER.debug("Calculating estimated reading:")
         _LOGGER.debug("  Official reading: %s on %s", latest_official, official_date)
         _LOGGER.debug("  Monthly readings available: %d", len(monthly_readings))
-        
-        # Sum all monthly usage since the official reading date
-        # Monthly data includes partial data for incomplete months
+        _LOGGER.debug("  Daily readings available: %d", len(daily_readings))
+
+        # Parse official date once
+        try:
+            official_date_str = official_date.split("T")[0] if "T" in official_date else official_date
+            official_dt = datetime.fromisoformat(official_date_str)
+        except (ValueError, AttributeError) as e:
+            _LOGGER.error("Invalid official date format: %s - %s", official_date, e)
+            return None
+
         usage_since_official = 0
-        
+
+        # Add daily usage from partial month (if provided by API)
+        for reading in daily_readings:
+            usage_since_official += reading.get("value", 0)
+            _LOGGER.debug("  Daily reading: %s = %s m³", reading.get("date"), reading.get("value", 0))
+
+        # Add monthly usage (complete months after the official reading)
+        # Monthly readings have start_date as first of the month
+        #
+        # Key insight: Only include monthly readings that occur AFTER the official reading date
+        # This ensures we never include historical data from before the official reading
+        official_month_start = official_dt.replace(day=1)
+
+        # Check if official reading was on the 1st of the month
+        is_first_of_month = (official_dt.day == 1)
+
         for reading in monthly_readings:
             reading_date = reading.get("start_date")
             reading_value = reading.get("value", 0)
-            _LOGGER.debug("  Monthly reading: %s = %s m³", reading_date, reading_value)
-            
-            # Compare just the date part (YYYY-MM-DD)
-            # Extract date from potentially longer datetime string
+
             if reading_date:
-                reading_date_only = reading_date.split("T")[0] if "T" in reading_date else reading_date
-                official_date_only = official_date.split("T")[0] if "T" in official_date else official_date
-                
-                _LOGGER.debug("    Comparing: %s >= %s", reading_date_only, official_date_only)
-                
-                # Reading must be on or after official reading date
-                if reading_date_only >= official_date_only:
-                    _LOGGER.debug("    -> Including this reading")
-                    usage_since_official += reading_value
-                else:
-                    _LOGGER.debug("    -> Skipping (before official date)")
-        
+                try:
+                    reading_date_str = reading_date.split("T")[0] if "T" in reading_date else reading_date
+                    reading_dt = datetime.fromisoformat(reading_date_str)
+
+                    # CRITICAL: Always compare against the actual official reading date, not just month boundary
+                    # This prevents including any months before the official reading
+                    if is_first_of_month:
+                        # Reading on 1st: include months from that date onwards
+                        should_include = reading_dt >= official_dt
+                    else:
+                        # Reading mid-month: exclude that month (covered by daily data)
+                        should_include = reading_dt > official_month_start
+
+                    if should_include:
+                        _LOGGER.debug("  Monthly reading: %s = %s m³ (included)", reading_date_str, reading_value)
+                        usage_since_official += reading_value
+                    else:
+                        _LOGGER.debug("  Monthly reading: %s = %s m³ (skipped - before official reading)", reading_date_str, reading_value)
+                except (ValueError, AttributeError) as e:
+                    _LOGGER.warning("Invalid reading date format: %s - %s", reading_date, e)
+                    continue
+
         estimated_current = latest_official + usage_since_official
         _LOGGER.debug("  Total usage since official: %s m³", usage_since_official)
         _LOGGER.debug("  Estimated current: %s m³", estimated_current)
-        
+
         return round(estimated_current, 3)
 
     @property
@@ -304,43 +360,67 @@ class SevernTrentEstimatedMeterReadingSensor(CoordinatorEntity, SensorEntity):
         """Return additional attributes."""
         if not self.coordinator.data:
             return {}
-        
+
         manual_data = self.coordinator.data.get("manual_meter", {})
         smart_data = self.coordinator.data.get("smart_meter", {})
-        
+
         if not manual_data or not smart_data:
             return {}
-        
+
         latest_official = manual_data.get("latest_reading")
         official_date = manual_data.get("reading_date")
         monthly_readings = smart_data.get("monthly_readings", [])
-        
+        daily_readings = smart_data.get("daily_readings_since_official", [])
+
         # Calculate usage since official reading
         usage_since_official = 0
         days_since_official = None
-        
+        monthly_periods_included = 0
+
         if official_date:
-            official_date_only = official_date.split("T")[0] if "T" in official_date else official_date
-            
-            # Add all monthly usage since official reading (on or after the date)
-            for reading in monthly_readings:
-                reading_date = reading.get("start_date")
-                if reading_date:
-                    reading_date_only = reading_date.split("T")[0] if "T" in reading_date else reading_date
-                    if reading_date_only >= official_date_only:
-                        usage_since_official += reading.get("value", 0)
-            
-            # Calculate days since official reading
-            from datetime import datetime
-            official_dt = datetime.fromisoformat(official_date)
-            today = datetime.now()
-            days_since_official = (today - official_dt).days
-        
+            try:
+                official_date_str = official_date.split("T")[0] if "T" in official_date else official_date
+                official_dt = datetime.fromisoformat(official_date_str)
+                official_month_start = official_dt.replace(day=1)
+                is_first_of_month = (official_dt.day == 1)
+
+                # Add daily usage
+                for reading in daily_readings:
+                    usage_since_official += reading.get("value", 0)
+
+                # Add monthly usage (complete months after official reading)
+                for reading in monthly_readings:
+                    reading_date = reading.get("start_date")
+                    if reading_date:
+                        try:
+                            reading_date_str = reading_date.split("T")[0] if "T" in reading_date else reading_date
+                            reading_dt = datetime.fromisoformat(reading_date_str)
+
+                            # Include months based on official reading day
+                            if is_first_of_month:
+                                # Compare against actual official date to prevent including prior months
+                                should_include = reading_dt >= official_dt
+                            else:
+                                should_include = reading_dt > official_month_start
+
+                            if should_include:
+                                usage_since_official += reading.get("value", 0)
+                                monthly_periods_included += 1
+                        except (ValueError, AttributeError):
+                            continue
+
+                # Calculate days since official reading
+                today = datetime.now()
+                days_since_official = (today - official_dt).days
+            except (ValueError, AttributeError) as e:
+                _LOGGER.warning("Error calculating attributes: %s", e)
+
         return {
             "last_official_reading": latest_official,
             "last_official_date": official_date,
             "usage_since_official": round(usage_since_official, 3) if usage_since_official else None,
             "days_since_official": days_since_official,
-            "monthly_periods_included": len([r for r in monthly_readings if (r.get("start_date", "").split("T")[0] if "T" in r.get("start_date", "") else r.get("start_date", "")) >= (official_date.split("T")[0] if "T" in official_date else official_date)]),
-            "estimation_note": "Official reading + monthly usage totals (includes partial current month)"
+            "daily_periods_included": len(daily_readings),
+            "monthly_periods_included": monthly_periods_included,
+            "estimation_note": "Official reading + daily usage (partial month) + monthly totals (complete months)"
         }


### PR DESCRIPTION
## [1.4.1] - 2026-01-17

### Fixed
- **Critical Fix**: Previous week sensor now shows correct values
  - Fixed data fetching to include complete previous week (Monday-Sunday)
  - Previously only fetched last 7 days, missing start of previous week when viewed mid-week
  - Now fetches from previous Monday onwards to ensure all weekly data is available
  - Resolves issue where previous week showed ~30% of actual usage
- **Critical Fix**: Estimated meter reading calculation now includes correct months
  - Fixed monthly period inclusion logic to compare against actual official reading date
  - When official reading is on 1st of month: compares monthly start dates against the official reading date (not month boundary)
  - When official reading is mid-month: excludes that month (partial month covered by daily data)
  - Prevents including historical months before the official reading
  - Resolves issue where estimated reading was too high (was including 8 months instead of 4)
  - For Oct 1st, 2025 official reading: now correctly includes only Oct, Nov, Dec 2025, Jan 2026 (4 periods)
- **Fix**: Removed invalid state class from Daily Average sensor
  - Removed `MEASUREMENT` state class which is incompatible with `WATER` device class
  - Sensor now correctly represents an average rate without statistics tracking
  - Resolves Home Assistant warning about impossible state class configuration
- **Critical Fix**: Changed from hourly to daily data fetching to match website behavior
  - Now uses `DAY_INTERVAL` instead of `HOUR_INTERVAL` for daily readings
  - Eliminates potential data discrepancies from hourly aggregation
  - Matches exact API behavior used by Severn Trent website
  - Should resolve remaining value mismatches between integration and website
- **Critical Fix**: Yesterday's usage now shows correct date
  - Changed from using most recent date in response to calculating yesterday as (today - 1 day)
  - Matches website behavior which explicitly fetches data for yesterday's date
  - Resolves issue where today's partial data was shown instead of yesterday's complete day

## [1.4.0] - 2026-01-17

### Breaking Changes
- **Removed** `sensor.severn_trent_weekly_total` (replaced with week-to-date sensor)
  - Users will need to update any automations, dashboards, or scripts that reference this sensor
  - Replace with `sensor.severn_trent_week_to_date` or `sensor.severn_trent_previous_week`

### Added
- **New Sensor**: `sensor.severn_trent_week_to_date` - Shows water consumption from Monday to present in the current week
  - Attributes include: `week_start`, `days_in_week`
  - Updates daily as new data becomes available
  - Uses Monday as the start of the week
- **New Sensor**: `sensor.severn_trent_previous_week` - Shows total water consumption for the previous complete week (Monday-Sunday)
  - Attributes include: `week_start`, `week_end`, `days_in_week`
  - Perfect for weekly comparisons and tracking
- Added `device_class` to all water consumption sensors for proper Home Assistant integration
- Enhanced logging with warnings for invalid measurement values

### Fixed
- **Critical Fix**: Corrected state classes for proper Home Assistant long-term statistics
  - `sensor.severn_trent_yesterday_usage` now uses `TOTAL_INCREASING` instead of `TOTAL`
  - `sensor.severn_trent_daily_average` now uses correct unit of measurement
  - All sensors now properly integrate with Home Assistant's Energy Dashboard
- **Critical Fix**: Improved estimated meter reading calculation to prevent double-counting
  - If official reading is mid-month (e.g., Oct 15th), now fetches daily data from that date to end of month
  - Uses monthly data only for complete months after the official reading month
  - Previously could double-count water usage from partial months
- **Critical Fix**: Replaced string-based date comparisons with proper datetime comparisons
  - More robust and prevents edge cases with different date formats
  - Added proper error handling for invalid date formats
- Removed hardcoded unit string formatting (no more `"m³/d"` strings)
- Improved error handling throughout with specific warning messages instead of silent failures

### Changed
- Updated API to accept official reading date parameter for smarter data fetching
- Data coordinator now fetches manual readings first, then uses official date for smart meter queries
- Enhanced estimated meter reading attributes to show both daily and monthly periods included
- Updated estimation note to reflect new calculation method

### Technical Improvements
- Better separation of concerns between daily and monthly data handling
- Reduced API calls while maintaining accuracy
- More detailed debug logging for troubleshooting
- Improved data validation with proper exception handling